### PR TITLE
Bugfix/list colliders outside of mask

### DIFF
--- a/ARA_MRTK3/Assets/Scripts/RepairManualDisplay.cs
+++ b/ARA_MRTK3/Assets/Scripts/RepairManualDisplay.cs
@@ -32,7 +32,6 @@ public class RepairManualDisplay : MonoBehaviour
 
     /// <summary>
     /// UpdateVisibility updates visibility if still on panel
-    /// TODO add height of children buttons open as well
     /// </summary>
     private void UpdateVisibility()
     {

--- a/ARA_MRTK3/Assets/Scripts/RepairManualDisplay.cs
+++ b/ARA_MRTK3/Assets/Scripts/RepairManualDisplay.cs
@@ -10,8 +10,38 @@ public class RepairManualDisplay : MonoBehaviour
 
     public Transform stepGroupParent;
     public ToggleCollection stepToggleCollection;
+
+    private StepScroller stepScroller;
+    private RectTransform rect;
+    private BoxCollider collider;
+
     public void UpdateDisplayInformation(string title)
     {
         titleText.text = title;
+    }
+
+    private void Start()
+    {
+        stepScroller = GetComponentInParent<StepScroller>();
+        if (stepScroller != null) stepScroller.OnMove += UpdateVisibility;
+
+        collider = GetComponent<BoxCollider>();
+        rect = GetComponent<RectTransform>();
+       
+    }
+
+    /// <summary>
+    /// UpdateVisibility updates visibility if still on panel
+    /// TODO add height of children buttons open as well
+    /// </summary>
+    private void UpdateVisibility()
+    {
+        if (stepScroller == null || collider == null || rect == null) return;
+
+        bool enabled =
+            stepScroller.transform.localPosition.y - (rect.rect.height/3f) < Mathf.Abs(rect.anchoredPosition.y) &&
+            stepScroller.transform.localPosition.y + stepScroller.content.rect.height - (rect.rect.height / 3f) > Mathf.Abs(rect.anchoredPosition.y);
+
+        collider.enabled = enabled;
     }
 }

--- a/ARA_MRTK3/Assets/StepScroller.cs
+++ b/ARA_MRTK3/Assets/StepScroller.cs
@@ -9,8 +9,8 @@ public class StepScroller : MonoBehaviour
 {
     [SerializeField] private float minY;
     [SerializeField] private float maxY;
-    [SerializeField] private RectTransform content;
-
+    public RectTransform content;
+    public Action OnMove;
     private void OnEnable()
     {
         NormalizedScroll(0);
@@ -24,8 +24,10 @@ public class StepScroller : MonoBehaviour
     {
         float y = Mathf.Lerp(minY, maxY, normalizedValue);
         content.anchoredPosition = new Vector2(content.anchoredPosition.x, y);
+        if (OnMove != null) OnMove.Invoke();
+
     }
-    
+
     public void SetMaxY(float maxY)
     {
         this.maxY = maxY;


### PR DESCRIPTION
Fixed the colliders on buttons when they are on a list and outside of the mask/panel by disabling them.

The display items compare their Y position with the containers position to see if they are above or below, they also do the same with the bottom of the panel.

