### PR TITLE
bugfix/ARA-163_Gallary_Close_Hover_State

### DIFF
--- a/ARA_MRTK3/Assets/Art 1/Materials/UX/CanvasBackplateQuad_Highlight.mat
+++ b/ARA_MRTK3/Assets/Art 1/Materials/UX/CanvasBackplateQuad_Highlight.mat
@@ -9,15 +9,15 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: CanvasBackplateQuad_Highlight
   m_Shader: {fileID: 4800000, guid: df5380aa6ab293c4fafbb942ed5da93f, type: 3}
-  m_ShaderKeywords: _ALPHABLEND_TRANS_ON _BORDER_LIGHT _BORDER_LIGHT_OPAQUE _BORDER_LIGHT_REPLACES_ALBEDO
+  m_ShaderKeywords: _ALPHATEST_ON _BORDER_LIGHT _BORDER_LIGHT_OPAQUE _BORDER_LIGHT_REPLACES_ALBEDO
     _BORDER_LIGHT_USES_COLOR _EDGE_SMOOTHING_AUTOMATIC _GRADIENT_LINEAR _ROUND_CORNERS
     _SPECULAR_HIGHLIGHTS _UI_CLIP_RECT_ROUNDED_INDEPENDENT
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
+  m_CustomRenderQueue: 2450
   stringTagMap:
-    RenderType: Fade
+    RenderType: Cutout
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -61,10 +61,10 @@ Material:
     - _ColorMask: 15
     - _ColorWriteMask: 15
     - _CullMode: 2
-    - _CustomMode: 2
+    - _CustomMode: 1
     - _Cutoff: 0.5
     - _DirectionalLight: 0
-    - _DstBlend: 10
+    - _DstBlend: 0
     - _EdgeSmoothingMode: 1
     - _EdgeSmoothingValue: 0.25
     - _EnableChannelMap: 0
@@ -99,7 +99,7 @@ Material:
     - _Max_Intensity_: 0.5
     - _Metallic: 0
     - _MipmapBias: -2
-    - _Mode: 3
+    - _Mode: 1
     - _Motion_: 0
     - _NearLightFade: 0
     - _NearPlaneFade: 0
@@ -140,7 +140,7 @@ Material:
     - _ZOffsetFactor: 0
     - _ZOffsetUnits: 0
     - _ZTest: 4
-    - _ZWrite: 0
+    - _ZWrite: 1
     - unity_GUIZTestMode: 4
     m_Colors:
     - _BlurBackgroundRect: {r: 0, g: 0, b: 1, a: 1}

--- a/ARA_MRTK3/Assets/Prefabs/JobRow_Prefab.prefab
+++ b/ARA_MRTK3/Assets/Prefabs/JobRow_Prefab.prefab
@@ -765,6 +765,7 @@ MonoBehaviour:
   materials: []
   images:
   - {fileID: 4788301642589031499}
+  switches: []
   debug: 0
 --- !u!114 &4788301642589031499
 MonoBehaviour:
@@ -2512,7 +2513,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123609900193760}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123610351082418}
@@ -2884,7 +2885,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123610082197362}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123611210063810}
@@ -2942,7 +2943,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123610113656813}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123611134959738}
@@ -3507,6 +3508,7 @@ MonoBehaviour:
   - {fileID: 2959861557931461798}
   images:
   - {fileID: 6890815030140780125}
+  switches: []
   debug: 0
 --- !u!114 &6890815030140780125
 MonoBehaviour:
@@ -4472,6 +4474,7 @@ MonoBehaviour:
   materials: []
   images:
   - {fileID: 9197719993587889886}
+  switches: []
   debug: 0
 --- !u!114 &3739612592101641523
 MonoBehaviour:
@@ -4534,7 +4537,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123610516720648}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123609825283073}
@@ -4594,7 +4597,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123610596995866}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5779473167483658863}
@@ -4688,7 +4691,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123610621255781}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123611081708234}
@@ -4746,7 +4749,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123610674331646}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123609696245253}
@@ -5363,7 +5366,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123611078017271}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123610376985335}
@@ -5556,7 +5559,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123611134959739}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8520123610113656812}
@@ -6064,7 +6067,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123611337195227}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123610447643380}
@@ -6255,7 +6258,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8520123611428010101}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8520123610210614775}

--- a/ARA_MRTK3/Assets/Prefabs/TaskRow_Prefab.prefab
+++ b/ARA_MRTK3/Assets/Prefabs/TaskRow_Prefab.prefab
@@ -997,6 +997,7 @@ MonoBehaviour:
   materials: []
   images:
   - {fileID: 3323922342172118521}
+  switches: []
   debug: 0
 --- !u!114 &3323922342172118521
 MonoBehaviour:
@@ -2049,6 +2050,7 @@ MonoBehaviour:
   materials: []
   images:
   - {fileID: 6528464901103478222}
+  switches: []
   debug: 0
 --- !u!114 &6837289006454680573
 MonoBehaviour:
@@ -2716,7 +2718,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7807644311686947272}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8508452045912707877}
@@ -3539,6 +3541,7 @@ MonoBehaviour:
   - {fileID: 8600276965032907662}
   images:
   - {fileID: 3293022875905686685}
+  switches: []
   debug: 0
 --- !u!114 &3305214220407197282
 MonoBehaviour:
@@ -3905,7 +3908,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7807644312699171269}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7807644313724655186}
@@ -4151,7 +4154,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7807644312994269654}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7807644312017772589}
@@ -4368,7 +4371,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7807644313189041458}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5355637932645798983}
@@ -4586,7 +4589,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7807644313481088605}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000012874603}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7807644312534223839}


### PR DESCRIPTION
In this branch the hover state of the Save and Close button in Camera mode is fixed

There was an issue with the highlighted material being a transparent type and the image preview always being drawn above the itrem regardless of z depth or position. Changing the type from transparent to cutout fixed this issue. The only downside is anywhere this material is used and shares a Z position with another ui item, it draws on top. so for a few prefabs I needed to pull the text for z position 0 to z position 1(or -1)  so that it was in front. 


https://dresslerconsulting.atlassian.net/browse/ARA-163?atlOrigin=eyJpIjoiYTgwYTExODk5YWJjNDVmYmIyNDZiYzI5NWE5Nzc0NGIiLCJwIjoiaiJ9