### PR TITLE
Feature/ara 166 hide gallary button in camera mode

### DIFF
--- a/ARA_MRTK3/Assets/Scripts/UI/HandMenuController.cs
+++ b/ARA_MRTK3/Assets/Scripts/UI/HandMenuController.cs
@@ -52,7 +52,7 @@ public class HandMenuController : MonoBehaviour
                 break;
             case MenuPage.takingPhoto:
                 cameraButton.SetActive(false);
-                galleryButton.SetActive(true);
+                galleryButton.SetActive(false);
                 rulerButton.SetActive(true);
                 voiceButton.SetActive(true);
                 break;


### PR DESCRIPTION
Easy fix of setting the gallery button in the hand menu to not appear in camera mode.



In the future I will be changing this script so its not an unoptimized switch case and something more efficient. 

https://dresslerconsulting.atlassian.net/browse/ARA-166?atlOrigin=eyJpIjoiZTViZGEwY2UyY2M3NDhlMmE5ZTUzYzY1NDI2MmE4Y2UiLCJwIjoiaiJ9