### PR TITLE
bugfix/ARA-159_PDF_File_Name_Header_Truncation

### DIFF
--- a/ARA_MRTK3/Assets/Prefabs/UI/PDFReader.prefab
+++ b/ARA_MRTK3/Assets/Prefabs/UI/PDFReader.prefab
@@ -2525,8 +2525,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -1.9399948}
+  m_SizeDelta: {x: 0, y: -15.100006}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5168806968430182712
 CanvasRenderer:
@@ -2556,7 +2556,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: New Title New Title
+  m_text: New PDF
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 1ed1409a5ec2641a98a5dcde7a856db0, type: 2}
   m_sharedMaterial: {fileID: 489737307049367580, guid: 1ed1409a5ec2641a98a5dcde7a856db0, type: 2}
@@ -2583,8 +2583,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 27.38
-  m_fontSizeBase: 27.38
+  m_fontSize: 18
+  m_fontSizeBase: 18
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -2601,7 +2601,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1


### PR DESCRIPTION
In this branch I matched the PDF header and title to the provided documents. Mainly truncating the text after 3 lines or 90 character count. I did this within TMProUGUI and not a script. Set the mode to ellipse, used proper margins and spacing as well as appropriate sized font (18) . 


It would be nice to store pdfs as a custom item instead of raw pdfs so that we can attach better looking titles to them



https://dresslerconsulting.atlassian.net/browse/ARA-159?atlOrigin=eyJpIjoiOTYxODBmODAyMmI1NGU0MGE0YWQ1ZWNiZmQ5YjQyYmEiLCJwIjoiaiJ9