### PR TITLE
Bugfix/ara 156/161 multiple pdfs of same document

### DIFF
--- a/ARA_MRTK3/Assets/Scripts/JobDisplay.cs
+++ b/ARA_MRTK3/Assets/Scripts/JobDisplay.cs
@@ -76,11 +76,13 @@ public class JobDisplay : MonoBehaviour
         pdfButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
         pdfButton.OnClicked.AddListener(() =>
         {
-            if (pdfButton.IsToggled == true)
+            MainMenuManager.Instance.pdfsManager.LoadOrHide(availableJobListItem.PreliminaryEstimation.Url);
+
+           /* if (pdfButton.IsToggled == true)
             {
                 if (pdfButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     pdfButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                MainMenuManager.Instance.pdfsManager.LoadPdf(availableJobListItem.PreliminaryEstimation.Url);
+                MainMenuManager.Instance.pdfsManager.LoadOrHide(availableJobListItem.PreliminaryEstimation.Url);
                 Debug.Log($"{gameObject.name}PDF Loaded");
                 pdfButton.ForceSetToggled(true, true);
             }
@@ -88,10 +90,10 @@ public class JobDisplay : MonoBehaviour
             {
                 if (pdfButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     pdfButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                MainMenuManager.Instance.pdfsManager.HidePdf(availableJobListItem.PreliminaryEstimation.Url);
+                MainMenuManager.Instance.pdfsManager.LoadOrHide(availableJobListItem.PreliminaryEstimation.Url);
                 Debug.Log($"{gameObject.name}PDF Hidden");
                 pdfButton.ForceSetToggled(false, true);
-            }
+            }*/
         });
 
         galleryButton.OnClicked.AddListener(async () =>

--- a/ARA_MRTK3/Assets/Scripts/MainMenuManager.cs
+++ b/ARA_MRTK3/Assets/Scripts/MainMenuManager.cs
@@ -216,39 +216,43 @@ public class MainMenuManager : MonoBehaviour
         estimationButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
         estimationButton.OnClicked.AddListener(() =>
         {
-            if (estimationButton.IsToggled == true)
+            pdfsManager.LoadOrHide(chosenJob.PreliminaryEstimation.Url);
+
+           /* if (estimationButton.IsToggled == true)
             {
                 if (estimationButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     estimationButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                pdfsManager.LoadPdf(chosenJob.PreliminaryEstimation.Url);
+                pdfsManager.LoadOrHide(chosenJob.PreliminaryEstimation.Url);
                 estimationButton.ForceSetToggled(true, true);
             }
             else if (estimationButton.IsToggled == false)
             {
                 if (estimationButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     estimationButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                pdfsManager.HidePdf(chosenJob.PreliminaryEstimation.Url);
+                pdfsManager.LoadOrHide(chosenJob.PreliminaryEstimation.Url);
                 estimationButton.ForceSetToggled(false, true);
-            }
+            }*/
         });
         scanDocButton.ForceSetToggled(false);
         scanDocButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
         scanDocButton.OnClicked.AddListener(() =>
         {
+            pdfsManager.LoadOrHide(chosenJob.PreliminaryScan.Url);
+/*
             if (scanDocButton.IsToggled == true)
             {
                 if (scanDocButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     scanDocButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                pdfsManager.LoadPdf(chosenJob.PreliminaryScan.Url);
+                pdfsManager.LoadOrHide(chosenJob.PreliminaryScan.Url);
                 scanDocButton.ForceSetToggled(true, true);
             }
             else if (scanDocButton.IsToggled == false)
             {
                 if (scanDocButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     scanDocButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                pdfsManager.HidePdf(chosenJob.PreliminaryScan.Url);
+                pdfsManager.LoadOrHide(chosenJob.PreliminaryScan.Url);
                 scanDocButton.ForceSetToggled(false, true);
-            }
+            }*/
         });
     }
     private UnityAction AddTaskToButton(TaskInfo task)

--- a/ARA_MRTK3/Assets/Scripts/UI/PDFsManager.cs
+++ b/ARA_MRTK3/Assets/Scripts/UI/PDFsManager.cs
@@ -141,7 +141,7 @@ public class PDFsManager : MonoBehaviour
 
     public void LoadOrHide(string fileName)
     {
-        PDFLoader loader = FindPDF(name);
+        PDFLoader loader = FindPDF(fileName);
 
         if (loader == null) { 
             LoadPdf(fileName);

--- a/ARA_MRTK3/Assets/Scripts/WorkingHUDManager.cs
+++ b/ARA_MRTK3/Assets/Scripts/WorkingHUDManager.cs
@@ -152,11 +152,13 @@ public class WorkingHUDManager : MonoBehaviour
         pdfButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
         pdfButton.OnClicked.AddListener(() =>
         {
-            if (pdfButton.IsToggled == true)
+            MainMenuManager.Instance.pdfsManager.LoadOrHide(pdfUrl);
+
+          /*  if (pdfButton.IsToggled == true)
             {
                 if (pdfButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     pdfButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                MainMenuManager.Instance.pdfsManager.LoadPdf(pdfUrl);
+                MainMenuManager.Instance.pdfsManager.LoadOrHide(pdfUrl);
                 Debug.Log($"{gameObject.name}PDF Loaded");
                 pdfButton.ForceSetToggled(true, true);
             }
@@ -164,10 +166,10 @@ public class WorkingHUDManager : MonoBehaviour
             {
                 if (pdfButton.ToggleMode != StatefulInteractable.ToggleType.Toggle)
                     pdfButton.ToggleMode = StatefulInteractable.ToggleType.Toggle;
-                MainMenuManager.Instance.pdfsManager.HidePdf(pdfUrl);
+                MainMenuManager.Instance.pdfsManager.LoadOrHide(pdfUrl);
                 Debug.Log($"{gameObject.name}PDF Hidden");
                 pdfButton.ForceSetToggled(false, true);
-            }
+            }*/
         });
 
 


### PR DESCRIPTION
In this branch i fix the issue of spawning the same pdf over and over.

The logic was in place already to search the name in a dictionary and hide if its in scene but there was an error in the code where i typed name instead of filename 

In the past you could press two pdf buttons back and forth and spawn infinite pdfs, now it will hide them properly 


https://dresslerconsulting.atlassian.net/browse/ARA-156?atlOrigin=eyJpIjoiYmEzYzczNjAyYWI0NGRjY2I0ZWRiMTMyNTExMzdlZjQiLCJwIjoiaiJ9

https://dresslerconsulting.atlassian.net/browse/ARA-161?atlOrigin=eyJpIjoiNGVkZTEwNjY1YjdhNGU1OTk0MTEyYjg0ZDVlMGZmMTMiLCJwIjoiaiJ9